### PR TITLE
Go1.13 errors compat

### DIFF
--- a/errwrap.go
+++ b/errwrap.go
@@ -44,6 +44,8 @@ func Wrap(outer, inner error) error {
 //
 // format is the format of the error message. The string '{{err}}' will
 // be replaced with the original error message.
+//
+// Deprecated: Use fmt.Errorf()
 func Wrapf(format string, err error) error {
 	outerMsg := "<nil>"
 	if err != nil {
@@ -148,6 +150,9 @@ func Walk(err error, cb WalkFunc) {
 		for _, err := range e.WrappedErrors() {
 			Walk(err, cb)
 		}
+	case interface{ Unwrap() error }:
+		cb(err)
+		Walk(e.Unwrap(), cb)
 	default:
 		cb(err)
 	}

--- a/errwrap.go
+++ b/errwrap.go
@@ -167,3 +167,7 @@ func (w *wrappedError) Error() string {
 func (w *wrappedError) WrappedErrors() []error {
 	return []error{w.Outer, w.Inner}
 }
+
+func (w *wrappedError) Unwrap() error {
+	return w.Inner
+}

--- a/errwrap_test.go
+++ b/errwrap_test.go
@@ -1,6 +1,7 @@
 package errwrap
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 )
@@ -90,5 +91,14 @@ func TestGetAllType(t *testing.T) {
 		if len(actual) != tc.Len {
 			t.Fatalf("%d: bad: %#v", i, actual)
 		}
+	}
+}
+
+func TestWrappedError_IsCompatibleWithErrorsUnwrap(t *testing.T) {
+	inner := errors.New("inner error")
+	err := Wrap(errors.New("outer"), inner)
+	actual := errors.Unwrap(err)
+	if actual != inner {
+		t.Fatal("wrappedError did not unwrap to inner")
 	}
 }

--- a/errwrap_test.go
+++ b/errwrap_test.go
@@ -42,6 +42,16 @@ func TestGetAll(t *testing.T) {
 			"foo",
 			1,
 		},
+		{
+			fmt.Errorf("foo: %w", fmt.Errorf("bar")),
+			"foo: bar",
+			1,
+		},
+		{
+			fmt.Errorf("foo: %w", fmt.Errorf("bar")),
+			"bar",
+			1,
+		},
 	}
 
 	for i, tc := range cases {
@@ -83,6 +93,11 @@ func TestGetAllType(t *testing.T) {
 			Wrapf("bar", Wrapf("baz", fmt.Errorf("foo"))),
 			Wrapf("", nil),
 			0,
+		},
+		{
+			fmt.Errorf("one: %w", fmt.Errorf("two: %w", fmt.Errorf("three"))),
+			fmt.Errorf("%w", errors.New("")),
+			2,
 		},
 	}
 


### PR DESCRIPTION
The first commit adds an `Unwrap` to the error type, so that errors created by `errwrap` can be unwrapped by `errors.Is` and `errors.As`.

The second commit adds another case to `Walk` (which is used by Get/GetAll/Contains/etc) to support the go1.13 wrap interface. This should allow existing packages to start using `fmt.Errorf` to wrap errors without having to change every `errwrap` call in a project.