### PR TITLE
Refactor tests: isolate test using errors.Unwrap

### DIFF
--- a/errwrap_go1.13_test.go
+++ b/errwrap_go1.13_test.go
@@ -1,0 +1,20 @@
+//go:build go1.13
+// +build go1.13
+
+package errwrap_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/errwrap"
+)
+
+func TestWrappedError_IsCompatibleWithErrorsUnwrap(t *testing.T) {
+	inner := errors.New("inner error")
+	err := errwrap.Wrap(errors.New("outer"), inner)
+	actual := errors.Unwrap(err)
+	if actual != inner {
+		t.Fatal("wrappedError did not unwrap to inner")
+	}
+}

--- a/errwrap_test.go
+++ b/errwrap_test.go
@@ -108,12 +108,3 @@ func TestGetAllType(t *testing.T) {
 		}
 	}
 }
-
-func TestWrappedError_IsCompatibleWithErrorsUnwrap(t *testing.T) {
-	inner := errors.New("inner error")
-	err := Wrap(errors.New("outer"), inner)
-	actual := errors.Unwrap(err)
-	if actual != inner {
-		t.Fatal("wrappedError did not unwrap to inner")
-	}
-}


### PR DESCRIPTION
Isolate TestWrappedError_IsCompatibleWithErrorsUnwrap which uses [errors.Unwrap](https://pkg.go.dev/errors#Unwrap) (which appeared with Go 1.13) in a separate test source compiled only for Go 1.13+.

Note: other tests that use `%w` with `fmt.Errorf` should be isolated too. I will provide those changes once this PR is accepted.