### PR TITLE
IND-3745 Dependabot intgeration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -14,4 +14,3 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "[chore] : "
-      

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,17 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "[chore] : "
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "[chore] : "
+      

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,8 +1,7 @@
 name: Build and Test Workflow
 
 on: 
-  pull_request:
-    branches: [master]
+  push:
 
 jobs:
     build:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,7 +1,8 @@
 name: Build and Test Workflow
 
 on: 
-  push:
+  pull_request:
+    branches: [master]
 
 jobs:
     build:


### PR DESCRIPTION
As per the memo: https://go.hashi.co/memo/eng-004,
Enabling the dependabot for identifying and updating the security and version updates in the repositories rather handling it manually.