### PR TITLE
fix: do not panic on Wrap(nil, err) and correct README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ with this pattern is that you completely lose the original `error` structure.
 
 Arguably the _correct_ approach is that you should make a custom structure
 implementing the `error` interface, and have the original error as a field
-on that structure, such [as this example](http://golang.org/pkg/os/#PathError).
+on that structure, such [as this example](https://pkg.go.dev/os#PathError).
 This is a good approach, but you have to know the entire chain of possible
 rewrapping that happens, when you might just care about one.
 
@@ -22,7 +22,7 @@ error is wrapped, and extracting that error.
 Install using `go get github.com/hashicorp/errwrap`.
 
 Full documentation is available at
-http://godoc.org/github.com/hashicorp/errwrap
+https://pkg.go.dev/github.com/hashicorp/errwrap
 
 ## Usage
 
@@ -65,11 +65,11 @@ func main() {
 #### Custom Types
 
 If you're already making custom types that properly wrap errors, then
-you can get all the functionality of `errwraps.Contains` and such by
+you can get all the functionality of `errwrap.Contains` and such by
 implementing the `Wrapper` interface with just one function. Example:
 
 ```go
-type AppError {
+type AppError struct {
   Code ErrorCode
   Err  error
 }

--- a/errwrap.go
+++ b/errwrap.go
@@ -102,7 +102,7 @@ func GetAll(err error, msg string) []error {
 	var result []error
 
 	Walk(err, func(err error) {
-		if err.Error() == msg {
+		if err != nil && err.Error() == msg {
 			result = append(result, err)
 		}
 	})
@@ -145,7 +145,11 @@ func Walk(err error, cb WalkFunc) {
 
 	switch e := err.(type) {
 	case *wrappedError:
-		cb(e.Outer)
+		// Outer may be nil (Wrap allows it); skip calling the
+		// callback with nil so helpers like GetAll never panic.
+		if e.Outer != nil {
+			cb(e.Outer)
+		}
 		Walk(e.Inner, cb)
 	case Wrapper:
 		cb(err)
@@ -169,6 +173,9 @@ type wrappedError struct {
 }
 
 func (w *wrappedError) Error() string {
+	if w.Outer == nil {
+		return "<nil>"
+	}
 	return w.Outer.Error()
 }
 

--- a/errwrap_test.go
+++ b/errwrap_test.go
@@ -112,6 +112,21 @@ func TestGetAllType(t *testing.T) {
 	}
 }
 
+func TestWrapNilOuter(t *testing.T) {
+	inner := errors.New("inner")
+	err := Wrap(nil, inner)
+
+	if got := err.Error(); got != "<nil>" {
+		t.Fatalf("Error() = %q, want %q", got, "<nil>")
+	}
+	if !Contains(err, "inner") {
+		t.Fatal("Contains should find inner when Outer is nil")
+	}
+	if got := Get(err, "inner"); got == nil || got.Error() != "inner" {
+		t.Fatalf("Get(inner) = %v, want inner", got)
+	}
+}
+
 func TestWrappedError_IsCompatibleWithErrorsUnwrap(t *testing.T) {
 	inner := errors.New("inner error")
 	err := Wrap(errors.New("outer"), inner)


### PR DESCRIPTION
## Summary
`Wrap` allows a nil outer error, but helpers assumed Outer was always non-nil:

- `Error()` and `GetAll`/`Contains` paniced on `Wrap(nil, err)`
- `Walk` invoked the callback with a nil Outer

Also fixes small README issues: `errwraps.Contains` typo, invalid `type AppError {` (missing `struct`), and docs links → pkg.go.dev.

## Changes
- Skip nil Outer in `Walk`; guard `GetAll` against nil errors
- `(*wrappedError).Error()` returns `"<nil>"` when Outer is nil (matches `Wrapf`)
- Add regression test for `Wrap(nil, inner)`
- README corrections

## Test plan
- [x] `go test ./...`