### PR TITLE
feat: add WrapNil and WrapfNil for nil-safe wrapping

### DIFF
--- a/errwrap.go
+++ b/errwrap.go
@@ -179,3 +179,24 @@ func (w *wrappedError) WrappedErrors() []error {
 func (w *wrappedError) Unwrap() error {
 	return w.Inner
 }
+
+// WrapNil is like Wrap, but returns nil when both outer and inner are nil.
+// If only one side is non-nil, that error is returned unwrapped. This avoids
+// an extra nil check at call sites that only wrap on error.
+func WrapNil(outer, inner error) error {
+	if outer == nil {
+		return inner
+	}
+	if inner == nil {
+		return outer
+	}
+	return Wrap(outer, inner)
+}
+
+// WrapfNil is like Wrapf, but returns nil when err is nil.
+func WrapfNil(format string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return Wrapf(format, err)
+}

--- a/wrap_nil_test.go
+++ b/wrap_nil_test.go
@@ -1,0 +1,30 @@
+package errwrap
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestWrapNil(t *testing.T) {
+	if WrapNil(nil, nil) != nil {
+		t.Fatal("expected nil")
+	}
+	inner := errors.New("inner")
+	if WrapNil(nil, inner) != inner {
+		t.Fatal("expected inner")
+	}
+	outer := errors.New("outer")
+	if WrapNil(outer, nil) != outer {
+		t.Fatal("expected outer")
+	}
+	w := WrapNil(outer, inner)
+	if w == nil || !Contains(w, "inner") || !Contains(w, "outer") {
+		t.Fatalf("wrap failed: %v", w)
+	}
+	if WrapfNil("x: {{err}}", nil) != nil {
+		t.Fatal("WrapfNil nil")
+	}
+	if WrapfNil("x: {{err}}", inner) == nil {
+		t.Fatal("WrapfNil expected error")
+	}
+}


### PR DESCRIPTION
## What

Add `WrapNil` and `WrapfNil`:

- `WrapNil(nil, nil)` → nil
- `WrapNil(nil, err)` / `WrapNil(err, nil)` → the non-nil error
- otherwise same as `Wrap`
- `WrapfNil` returns nil when `err` is nil

## Why

Call sites often wrap only on error and want to avoid an extra nil check. See #5.

## Test

- `TestWrapNil`